### PR TITLE
Makefile也用build目录

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       run: sudo apt-get update -y && sudo apt-get -y install --no-install-recommends mtools nasm xorriso imagemagick qemu-system-x86
 
     - name: Build Kernel
-      run: make
+      run: make VERBOSE=1
 
     - name: Run and take screenshot
       shell: bash

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ sudo apk add gcc make xmake nasm grub-pc xorriso qemu-system
 4. **清理与测试**：
    - 输入“make clean” or “xmake clean”清理所有中间文件及UxImage和镜像。
    - （xmake编译后需要用xmake clean清理，make编译用make clean清理，为防止玄学事情发生，务必这样做！）
-   - （xmake编译后通过xmake clean会残留一个./build/文件夹，目的是防止测试时误删用户文件，请在提交前将他删除！）
+   - （编译后通过清理会残留一个./build/文件夹，目的是防止测试时误删用户文件）
    - 输入“make run” or “xmake run”即可通过qemu测试启动iso镜像。
    - 输入“make runk”可以通过qemu测试内核文件启动。
    - “make run-db”和“make runk-db”可以调出对应启动模式的调试（控制台显示汇编代码）。

--- a/boot/boot.s
+++ b/boot/boot.s
@@ -42,9 +42,7 @@ MBOOT_CHECKSUM EQU -(MBOOT_HEADER_MAGIC + MBOOT_HEADER_FLAGS)
 ; -----------------------------------------------------------
 
 [BITS 32]							; 所有代码以 32-bit 的方式编译
-SECTION .text						; 代码段从这里开始
-
-; 在代码段的起始位置设置符合 Multiboot 规范的标记
+SECTION .multiboot						; Multiboot段从这里开始
 
 DD MBOOT_HEADER_MAGIC				; GRUB 会通过这个魔数判断该映像是否支持
 DD MBOOT_HEADER_FLAGS				; GRUB 的一些加载时选项，其详细注释在定义处
@@ -55,6 +53,7 @@ DD 1024	; width宽度
 DD 768	; height高度
 DD 32	; bpp
 
+SECTION .text						; 代码段从这里开始
 [GLOBAL start]						; 向外部声明内核代码入口，此处提供该声明给链接器
 [GLOBAL glb_mboot_ptr]				; 向外部声明 struct multiboot * 变量
 [EXTERN kernel_init]				; 声明内核 C 代码的初始化函数

--- a/include/uinxed.h
+++ b/include/uinxed.h
@@ -14,8 +14,8 @@
 
 #define BUILD_DATE __DATE__
 #define BUILD_TIME __TIME__
-#define KERNL_VERS "v0.0.2412282" // Version format: v[VERSION].[PACK].YYMMDDF
-#define KERNL_BUID 290
+#define KERNL_VERS "v0.0.2412283" // Version format: v[VERSION].[PACK].YYMMDDF
+#define KERNL_BUID 291
 #define PROJK_COPY "Copyright 2020 ViudiraTech. All Rights Reserved."
 
 #define SHOW_START_LOGO


### PR DESCRIPTION
make改成和xmake一样用 build 目录，并生成 .d 文件，减少玄学事件发生。对其他部分稍作清理。

-----------

顺便修了boot.s，加了.multiboot section。kernel.ld有写.multiboot，代码里却没用。

能起来是因为bootloader会在文件最开头一个区域找，而不是仅仅看最开始的位置。

而 ld 时汇编的的.o文件在C语言的.o文件前面，所以有很大概率能让bootloader找到。但是这不合理。