### PR TITLE
Fix get_year() returning incorrect year

### DIFF
--- a/kernel/chipset/cmos.c
+++ b/kernel/chipset/cmos.c
@@ -67,6 +67,11 @@ uint32_t get_mon_hex(void)
 /* Get the current year */
 uint32_t get_year(void)
 {
-    /* The year stored in CMOS is from 2000, so you need to add 2010 to get the actual year */
-    return (BCD_HEX(read_cmos(CMOS_CUR_CEN)) * 100) + BCD_HEX(read_cmos(CMOS_CUR_YEAR)) - 30 + 2010;
+    uint32_t century = BCD_HEX(read_cmos(CMOS_CUR_CEN));
+    uint32_t year    = BCD_HEX(read_cmos(CMOS_CUR_YEAR));
+
+    if (century < 10 || century > 30) {
+        century = (year >= 70) ? 19 : 20;
+    }
+    return century * 100 + year;
 }


### PR DESCRIPTION
The old formula subtracted 30 then added 2010, effectively adding 1980 to the actual year (e.g. 2026 returned as 4006).

The century register already provides the correct century value, so the calculation is simply century * 100 + year. Added a fallback for BIOSes that don't implement the century register (infer century from the year value).